### PR TITLE
Phantoms will no longer target players with insomnia disabled

### DIFF
--- a/src/main/java/com/rha1117/freedomofinsomnia/mixin/PhantomTargetMixin.java
+++ b/src/main/java/com/rha1117/freedomofinsomnia/mixin/PhantomTargetMixin.java
@@ -1,0 +1,22 @@
+package com.rha1117.freedomofinsomnia.mixin;
+
+import com.rha1117.freedomofinsomnia.CommandMixinInterface;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.List;
+
+@Mixin(targets = "net.minecraft.entity.mob.PhantomEntity$FindTargetGoal")
+public class PhantomTargetMixin {
+
+    @ModifyVariable(method = "canStart()Z", at = @At("STORE"), index = 1)
+    private List<PlayerEntity> modifyTargetList(List<PlayerEntity> value){
+
+        value.removeIf(player -> ((CommandMixinInterface) player).freedom_of_insomnia$getInsomniaDisabled());
+
+        return value;
+    }
+
+}

--- a/src/main/resources/freedomofinsomnia.mixins.json
+++ b/src/main/resources/freedomofinsomnia.mixins.json
@@ -3,8 +3,9 @@
   "package": "com.rha1117.freedomofinsomnia.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "ServerPlayerEntityMixin",
-    "PhantomSpawnerMixin"
+    "PhantomSpawnerMixin",
+    "PhantomTargetMixin",
+    "ServerPlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This small PR updates the mod to make it so that phantoms don't target players who have insomnia enabled. As someone who uses this mod in a server of mine, I find that many players expect that to be case, yet it currently isn't. I have yet to properly test this with real players; I have only been able to test it with fake Carpet players.

- A new mixin, named `PhantomTargetMixin` was created. It targets the `PhantomEntity$FindTargetGoal` inner class, and modifies the `canStart()` method. 
- It modifies the `list` variable which is assigned a list of players that meet a certain predicate and are within a certain radius of the phantom. The mixin removes all players who have insomnia disabled from this list. This way, these players are never eligible to be targets of the phantom.